### PR TITLE
CircleCI changes for build, push and deploy of NH to staging and prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,7 @@ workflows:
               branches: 
                 only: [develop]  
         - deploy-prod:
-            context: aws-infra
+            context: aws-prod
             requires: 
               - push-api
               - push-device

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,15 +22,16 @@ docker_env: &docker_env
 
       echo "export DOCKER_TAG=$TAG" >> $BASH_ENV
       echo "export DOCKER_VERSION_TAG=$VERSION" >> $BASH_ENV
+      echo "export DOCKER_REGISTRY=public.ecr.aws/o0z1n0s8/nerveshub" >> $BASH_ENV
 
 docker_build_release: &docker_build_release
   run:
     name: Build docker images
     command: |
       docker build \
-        -t public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_TAG \
-        -t public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_VERSION_TAG \
-        -t public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:latest \
+        -t $DOCKER_REGISTRY/$APP_NAME:$DOCKER_TAG \
+        -t $DOCKER_REGISTRY/$APP_NAME:$DOCKER_VERSION_TAG \
+        -t $DOCKER_REGISTRY/$APP_NAME:latest
         -f apps/$APP_NAME/rel/Dockerfile.build .
 
 docker_save: &docker_save
@@ -39,13 +40,13 @@ docker_save: &docker_save
     command: |
       mkdir -p /docker
       docker save \
-        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_TAG \
+        $DOCKER_REGISTRY/$APP_NAME:$DOCKER_TAG \
         -o /docker/$APP_NAME-$DOCKER_TAG.tar
       docker save \
-        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_VERSION_TAG \
+        $DOCKER_REGISTRY/$APP_NAME:$DOCKER_VERSION_TAG \
         -o /docker/$APP_NAME-$DOCKER_VERSION_TAG.tar
       docker save \
-        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:latest \
+        $DOCKER_REGISTRY/$APP_NAME:latest \
         -o /docker/$APP_NAME-latest.tar
 
 docker_import: &docker_import
@@ -64,9 +65,9 @@ docker_push: &docker_push
     name: Push docker images to ECR
     command: |
       aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/o0z1n0s8
-      docker push public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_TAG
+      docker push $DOCKER_REGISTRY/$APP_NAME:$DOCKER_TAG
 
-docker_login: &docker_login
+aws_login: &aws_login
   aws-cli/setup:
     aws-access-key-id: AWS_ACCESS_KEY
     aws-secret-access-key: AWS_ACCESS_SECRET
@@ -84,7 +85,7 @@ docker_release: &docker_release
 version: 2.1
 orbs:
   docker: circleci/docker@2.0.3
-  aws-cli: circleci/aws-cli@2.0  
+  aws-cli: circleci/aws-cli@3.1.3
 jobs:
   fetch_deps:
     docker:
@@ -209,7 +210,7 @@ jobs:
           keys:
             - docker-www-{{ .Branch }}-{{ .Revision }}
       - <<: *docker_import
-      - <<: *docker_login
+      - <<: *aws_login
       - <<: *docker_push
 
   push-device:
@@ -223,7 +224,7 @@ jobs:
           keys:
             - docker-device-{{ .Branch }}-{{ .Revision }}
       - <<: *docker_import
-      - <<: *docker_login
+      - <<: *aws_login
       - <<: *docker_push
 
   push-api:
@@ -237,7 +238,7 @@ jobs:
           keys:
             - docker-api-{{ .Branch }}-{{ .Revision }}
       - <<: *docker_import
-      - <<: *docker_login
+      - <<: *aws_login
       - <<: *docker_push
 
   release-www:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ docker_env: &docker_env
       echo "export DOCKER_TAG=$TAG" >> $BASH_ENV
       echo "export DOCKER_VERSION_TAG=$VERSION" >> $BASH_ENV
       echo "export BRANCH=$CIRCLE_BRANCH" >> $BASH_ENV
-      echo "export DOCKER_REGISTRY=public.ecr.aws/o0z1n0s8/nerveshub" >> $BASH_ENV
+      echo "export DOCKER_REGISTRY=005352568091.dkr.ecr.eu-west-1.amazonaws.com" >> $BASH_ENV
 
 docker_build_release: &docker_build_release
   run:
@@ -295,21 +295,21 @@ workflows:
               tags:
                 only: /.*/
         - push-www:
-            context: aws
+            context: aws-infra
             requires:
               - build-www
             filters:
               branches:
                 only: [main,develop]
         - push-device:
-            context: aws
+            context: aws-infra
             requires:
               - build-device
             filters:
               branches:
                 only: [main,develop]
         - push-api:
-            context: aws
+            context: aws-infra
             requires:
               - build-api
             filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ docker_push: &docker_push
   run: 
     name: Push docker images to ECR
     command: |
-      aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/o0z1n0s8
+      aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin 005352568091.dkr.ecr.eu-west-1.amazonaws.com
       docker push $DOCKER_REGISTRY/$APP_NAME:$DOCKER_TAG
       docker push $DOCKER_REGISTRY/$APP_NAME:$BRANCH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ docker_build_release: &docker_build_release
       docker build \
         -t $DOCKER_REGISTRY/$APP_NAME:$DOCKER_TAG \
         -t $DOCKER_REGISTRY/$APP_NAME:$DOCKER_VERSION_TAG \
-        -t $DOCKER_REGISTRY/$APP_NAME:latest
+        -t $DOCKER_REGISTRY/$APP_NAME:latest \
         -f apps/$APP_NAME/rel/Dockerfile.build .
 
 docker_save: &docker_save

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ docker_env: &docker_env
 
       echo "export DOCKER_TAG=$TAG" >> $BASH_ENV
       echo "export DOCKER_VERSION_TAG=$VERSION" >> $BASH_ENV
-      echo "export BRANCH=$CIRCLE_BRANCH"
+      echo "export BRANCH=$CIRCLE_BRANCH" >> $BASH_ENV
       echo "export DOCKER_REGISTRY=public.ecr.aws/o0z1n0s8/nerveshub" >> $BASH_ENV
 
 docker_build_release: &docker_build_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ docker_env: &docker_env
 
       echo "export DOCKER_TAG=$TAG" >> $BASH_ENV
       echo "export DOCKER_VERSION_TAG=$VERSION" >> $BASH_ENV
+      echo "export BRANCH=$CIRCLE_BRANCH"
       echo "export DOCKER_REGISTRY=public.ecr.aws/o0z1n0s8/nerveshub" >> $BASH_ENV
 
 docker_build_release: &docker_build_release
@@ -31,6 +32,7 @@ docker_build_release: &docker_build_release
       docker build \
         -t $DOCKER_REGISTRY/$APP_NAME:$DOCKER_TAG \
         -t $DOCKER_REGISTRY/$APP_NAME:$DOCKER_VERSION_TAG \
+        -t $DOCKER_REGISTRY/$APP_NAME:$BRANCH \
         -t $DOCKER_REGISTRY/$APP_NAME:latest \
         -f apps/$APP_NAME/rel/Dockerfile.build .
 
@@ -66,6 +68,7 @@ docker_push: &docker_push
     command: |
       aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/o0z1n0s8
       docker push $DOCKER_REGISTRY/$APP_NAME:$DOCKER_TAG
+      docker push $DOCKER_REGISTRY/$APP_NAME:$BRANCH
 
 aws_login: &aws_login
   aws-cli/setup:
@@ -81,6 +84,14 @@ docker_release: &docker_release
         public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_VERSION_TAG
       docker push \
         public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:latest
+
+redeploy-service: &redeploy-service
+  run:
+    name: Redeploy tasks
+    command: |
+      for i in services; do
+        aws ecs update-service --cluster $CLUSTER --service $i --force-new-deployment 
+      done 
 
 version: 2.1
 orbs:
@@ -241,44 +252,21 @@ jobs:
       - <<: *aws_login
       - <<: *docker_push
 
-  release-www:
+  deploy-staging:
     <<: *defaults
     steps:
-      - checkout
-      - run: echo "export APP_NAME=nerves_hub_www" >> $BASH_ENV
-      - <<: *remote_docker
-      - <<: *docker_env
-      - restore_cache:
-          keys:
-            - docker-www-{{ .Branch }}-{{ .Revision }}
-      - <<: *docker_import
-      - <<: *docker_release
+      - run: echo "export CLUSTER=nerves-hub-staging" >> $BASH_ENV
+      - run: echo "export services=[nerves-hub-device,nerves-hub-api,nerves-hub-www]" >> $BASH_ENV
+      - <<: *aws_login
+      - <<: *redeploy-service   
 
-  release-device:
+  deploy-prod:
     <<: *defaults
     steps:
-      - checkout
-      - run: echo "export APP_NAME=nerves_hub_device" >> $BASH_ENV
-      - <<: *remote_docker
-      - <<: *docker_env
-      - restore_cache:
-          keys:
-            - docker-device-{{ .Branch }}-{{ .Revision }}
-      - <<: *docker_import
-      - <<: *docker_release
-
-  release-api:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: echo "export APP_NAME=nerves_hub_api" >> $BASH_ENV
-      - <<: *remote_docker
-      - <<: *docker_env
-      - restore_cache:
-          keys:
-            - docker-api-{{ .Branch }}-{{ .Revision }}
-      - <<: *docker_import
-      - <<: *docker_release
+      - run: echo "export CLUSTER=nerves-hub" >> $BASH_ENV
+      - run: echo "export services=[nerves-hub-device,nerves-hub-api,nerves-hub-www]" >> $BASH_ENV
+      - <<: *aws_login
+      - <<: *redeploy-service    
 
 workflows:
   version: 2
@@ -289,24 +277,15 @@ workflows:
               tags:
                 only: /.*/
         - test_elixir:
-            context: org-global
             requires:
               - fetch_deps
             filters:
               tags:
                 only: /.*/
-        # - test_javascript:
-        #     context: org-global
-        #     requires:
-        #       - fetch_deps
-        #     filters:
-        #       tags:
-        #         only: /.*/
         - build-www:
             context: aws
             requires:
               - test_elixir
-              # - test_javascript
             filters:
               tags:
                 only: /.*/
@@ -330,45 +309,36 @@ workflows:
               - build-www
             filters:
               branches:
-                only: main
+                only: [main,develop]
         - push-device:
             context: aws
             requires:
               - build-device
             filters:
               branches:
-                only: main
+                only: [main,develop]
         - push-api:
             context: aws
             requires:
               - build-api
             filters:
               branches:
-                only: main
-        - release-www:
-            context: aws
-            requires:
-              - build-www
+                only: [main,develop]
+        - deploy-staging:
+            context: aws-infra
+            requires: 
+              - push-api
+              - push-device
+              - push-www
             filters:
-              branches:
-                ignore: /.*/
-              tags:
-                only: /v.*/
-        - release-device:
-            context: aws
-            requires:
-              - build-device
+              branches: 
+                only: [develop]  
+        - deploy-prod:
+            context: aws-infra
+            requires: 
+              - push-api
+              - push-device
+              - push-www
             filters:
-              branches:
-                ignore: /.*/
-              tags:
-                only: /v.*/
-        - release-api:
-            context: aws
-            requires:
-              - build-api
-            filters:
-              branches:
-                ignore: /.*/
-              tags:
-                only: /v.*/
+              branches: 
+                only: [main]                 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,15 +76,6 @@ aws_login: &aws_login
     aws-secret-access-key: AWS_ACCESS_SECRET
     aws-region: AWS_REGION_NAME        
 
-docker_release: &docker_release
-  run:
-    name: Release docker images to dockerhub
-    command: |
-      docker push \
-        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_VERSION_TAG
-      docker push \
-        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:latest
-
 redeploy-service: &redeploy-service
   run:
     name: Redeploy tasks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,9 @@ docker_build_release: &docker_build_release
     name: Build docker images
     command: |
       docker build \
-        -t nerveshub/$APP_NAME:$DOCKER_TAG \
-        -t nerveshub/$APP_NAME:$DOCKER_VERSION_TAG \
-        -t nerveshub/$APP_NAME:latest \
+        -t public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_TAG \
+        -t public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_VERSION_TAG \
+        -t public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:latest \
         -f apps/$APP_NAME/rel/Dockerfile.build .
 
 docker_save: &docker_save
@@ -39,13 +39,13 @@ docker_save: &docker_save
     command: |
       mkdir -p /docker
       docker save \
-        nerveshub/$APP_NAME:$DOCKER_TAG \
+        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_TAG \
         -o /docker/$APP_NAME-$DOCKER_TAG.tar
       docker save \
-        nerveshub/$APP_NAME:$DOCKER_VERSION_TAG \
+        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_VERSION_TAG \
         -o /docker/$APP_NAME-$DOCKER_VERSION_TAG.tar
       docker save \
-        nerveshub/$APP_NAME:latest \
+        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:latest \
         -o /docker/$APP_NAME-latest.tar
 
 docker_import: &docker_import
@@ -60,26 +60,31 @@ docker_import: &docker_import
         -i /docker/$APP_NAME-latest.tar
 
 docker_push: &docker_push
-  run:
-    name: Push commit image to dockerhub
+  run: 
+    name: Push docker images to ECR
     command: |
-      docker login -u $DOCKER_USER -p $DOCKER_PASS
-      docker push \
-        nerveshub/$APP_NAME:$DOCKER_TAG
+      aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/o0z1n0s8
+      docker push public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_TAG
+
+docker_login: &docker_login
+  aws-cli/setup:
+    aws-access-key-id: AWS_ACCESS_KEY
+    aws-secret-access-key: AWS_ACCESS_SECRET
+    aws-region: AWS_REGION_NAME        
 
 docker_release: &docker_release
   run:
     name: Release docker images to dockerhub
     command: |
-      docker login -u $DOCKER_USER -p $DOCKER_PASS
       docker push \
-        nerveshub/$APP_NAME:$DOCKER_VERSION_TAG
+        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:$DOCKER_VERSION_TAG
       docker push \
-        nerveshub/$APP_NAME:latest
+        public.ecr.aws/o0z1n0s8/nerveshub/$APP_NAME:latest
 
 version: 2.1
 orbs:
   docker: circleci/docker@2.0.3
+  aws-cli: circleci/aws-cli@2.0  
 jobs:
   fetch_deps:
     docker:
@@ -96,7 +101,7 @@ jobs:
       - run: mix do deps.get
       - save_cache:
           key: mix-deps-v1-{{ .Branch }}-{{ checksum "mix.lock" }}
-          paths: "deps"
+          paths: ["deps"]
 
   test_elixir:
     docker:
@@ -165,7 +170,7 @@ jobs:
       - <<: *docker_save
       - save_cache:
           key: docker-www-{{ .Branch }}-{{ .Revision }}
-          paths: "/docker"
+          paths: ["/docker"]
 
   build-device:
     <<: *defaults
@@ -178,7 +183,7 @@ jobs:
       - <<: *docker_save
       - save_cache:
           key: docker-device-{{ .Branch }}-{{ .Revision }}
-          paths: "/docker"
+          paths: ["/docker"]
 
   build-api:
     <<: *defaults
@@ -191,7 +196,7 @@ jobs:
       - <<: *docker_save
       - save_cache:
           key: docker-api-{{ .Branch }}-{{ .Revision }}
-          paths: "/docker"
+          paths: ["/docker"]
 
   push-www:
     <<: *defaults
@@ -204,6 +209,7 @@ jobs:
           keys:
             - docker-www-{{ .Branch }}-{{ .Revision }}
       - <<: *docker_import
+      - <<: *docker_login
       - <<: *docker_push
 
   push-device:
@@ -217,6 +223,7 @@ jobs:
           keys:
             - docker-device-{{ .Branch }}-{{ .Revision }}
       - <<: *docker_import
+      - <<: *docker_login
       - <<: *docker_push
 
   push-api:
@@ -230,6 +237,7 @@ jobs:
           keys:
             - docker-api-{{ .Branch }}-{{ .Revision }}
       - <<: *docker_import
+      - <<: *docker_login
       - <<: *docker_push
 
   release-www:
@@ -294,7 +302,7 @@ workflows:
         #       tags:
         #         only: /.*/
         - build-www:
-            context: org-global
+            context: aws
             requires:
               - test_elixir
               # - test_javascript
@@ -302,42 +310,42 @@ workflows:
               tags:
                 only: /.*/
         - build-device:
-            context: org-global
+            context: aws
             requires:
               - test_elixir
             filters:
               tags:
                 only: /.*/
         - build-api:
-            context: org-global
+            context: aws
             requires:
               - test_elixir
             filters:
               tags:
                 only: /.*/
         - push-www:
-            context: org-global
+            context: aws
             requires:
               - build-www
             filters:
               branches:
                 only: main
         - push-device:
-            context: org-global
+            context: aws
             requires:
               - build-device
             filters:
               branches:
                 only: main
         - push-api:
-            context: org-global
+            context: aws
             requires:
               - build-api
             filters:
               branches:
                 only: main
         - release-www:
-            context: org-global
+            context: aws
             requires:
               - build-www
             filters:
@@ -346,7 +354,7 @@ workflows:
               tags:
                 only: /v.*/
         - release-device:
-            context: org-global
+            context: aws
             requires:
               - build-device
             filters:
@@ -355,7 +363,7 @@ workflows:
               tags:
                 only: /v.*/
         - release-api:
-            context: org-global
+            context: aws
             requires:
               - build-api
             filters:


### PR DESCRIPTION
This commit updates the CircleCI configuration so that the docker image is pushed to Zola's AWS ECR registry.

This is achieved by changing the default dockerhub references to Zola's aws registry.