### PR TITLE
Fix CACertificateController show

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/ca_certificate_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/ca_certificate_controller.ex
@@ -23,7 +23,7 @@ defmodule NervesHubAPIWeb.CACertificateController do
     end
   end
 
-  def show(%{assigns: %{org: _org}} = conn, %{"serial_or_ski" => "/ski/" <> ski16}) do
+  def show(%{assigns: %{org: _org}} = conn, %{"ski" => ski16}) do
     ski = ski16 |> String.upcase() |> Base.decode16!()
 
     with {:ok, ca_certificate} <- Devices.get_ca_certificate_by_ski(ski) do
@@ -31,7 +31,7 @@ defmodule NervesHubAPIWeb.CACertificateController do
     end
   end
 
-  def show(%{assigns: %{org: org}} = conn, %{"serial_or_ski" => serial}) do
+  def show(%{assigns: %{org: org}} = conn, %{"serial" => serial}) do
     with {:ok, ca_certificate} <- Devices.get_ca_certificate_by_org_and_serial(org, serial) do
       render(conn, "show.json", ca_certificate: ca_certificate)
     end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -66,7 +66,8 @@ defmodule NervesHubAPIWeb.Router do
         scope "/ca_certificates" do
           get("/", CACertificateController, :index)
           post("/", CACertificateController, :create)
-          get("/:serial_or_ski", CACertificateController, :show)
+          get("/ski/:ski", CACertificateController, :show, as: :ca_certificate_by_ski)
+          get("/:serial", CACertificateController, :show)
           delete("/:serial", CACertificateController, :delete)
         end
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
@@ -51,10 +51,24 @@ defmodule NervesHubAPIWeb.CACertificateControllerTest do
   describe "view ca_certificate" do
     setup [:create_ca_certificate_with_jitp]
 
+    test "renders when given a valid serial", %{
+      conn: conn,
+      org: org,
+      ca_certificate: ca_certificate
+    } do
+      %{serial: serial, description: description} = ca_certificate
+
+      conn = get(conn, Routes.ca_certificate_path(conn, :show, org.name, serial))
+
+      resp_data = json_response(conn, 200)["data"]
+      assert %{"serial" => ^serial} = resp_data
+      assert %{"description" => ^description} = resp_data
+    end
+
     test "renders when given valid SKI", %{conn: conn, org: org, ca_certificate: ca_certificate} do
       ski16 = Base.encode16(ca_certificate.ski)
 
-      conn = get(conn, Routes.ca_certificate_path(conn, :show, org.name, "/ski/#{ski16}"))
+      conn = get(conn, Routes.ca_certificate_by_ski_path(conn, :show, org.name, "#{ski16}"))
 
       resp_data = json_response(conn, 200)["data"]
 
@@ -74,7 +88,7 @@ defmodule NervesHubAPIWeb.CACertificateControllerTest do
     test "supports legacy behaviour", %{conn: conn, org: org, ca_certificate: ca_certificate} do
       ski64 = Base.encode64(ca_certificate.ski)
 
-      conn = get(conn, Routes.ca_certificate_path(conn, :jitp, org.name, "#{ski64}"))
+      conn = get(conn, Routes.ca_certificate_path(conn, :jitp, org.name, ski64))
 
       resp_data = json_response(conn, 200)["data"]
 


### PR DESCRIPTION
In order to support:

  get("/ski/:ski", CACertificateController, :show)
  get("/:serial", CACertificateController, :show)

in the router we need to specify the "ski" as a customized route to ensure the "helper" can generate the correct urls. Without it, the help always generates a "ski" url.